### PR TITLE
Fix macro path issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 description = """
 Custom derive and procedural macros for easy FFI with ocaml on top of the ocaml crate
 """
-
+edition = "2018"
 categories = [ "external-ffi-bindings" ]
 keywords = [ "ocaml", "ffi", "derive" ]
 readme = "README.md"

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -105,7 +105,7 @@ pub fn tovalue_derive(s: synstructure::Structure) -> proc_macro2::TokenStream {
         gen impl ocaml::ToValue for @Self {
             fn to_value(&self) -> ocaml::Value {
                 unsafe {
-                    caml_body!{ | |, <value>, {
+                    ::ocaml::caml_body!{ | |, <value>, {
                         match *self {
                              #(#body),*
                         }

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -107,7 +107,7 @@ pub fn ocaml(_attribute: TokenStream, function: TokenStream) -> TokenStream {
     let body = if returns {
         quote!(
             #rust_code
-            caml_body!{ | #(#params), * |, <return_value>, {
+            ::ocaml::caml_body!{ | #(#params), * |, <return_value>, {
                 let rust_val = internal(#(#arguments),*);
                 return_value = ::ocaml::ToValue::to_value(&rust_val);
             }
@@ -117,7 +117,7 @@ pub fn ocaml(_attribute: TokenStream, function: TokenStream) -> TokenStream {
     } else {
         quote!(
             #rust_code
-            caml_body!{ | #(#params), * |, @code {
+            ::ocaml::caml_body!{ | #(#params), * |, @code {
                 internal(#(#arguments),*);
             }};
             return


### PR DESCRIPTION
Fix #3.

This PR addresses the macro path issue, since Rust 2018 has a major haul with both the module path system and macro scoping.

Downstream users now just need to make sure that `ocaml` crate is listed as a direct dependency of their crates.