### PR TITLE
Handle panic in rust ffi functions to prevent unwinding into ocaml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,13 @@ derive = [ "synstructure" ]
 stubs = ["syn/full"]
 
 [dependencies]
-synstructure = { version = "0.10", optional = true }
-syn = "0.15"
-quote = "0.6"
-proc-macro2 = "0.4"
+quote = "1.0"
+proc-macro2 = "1.0"
+
+[dependencies.syn]
+version = "1.0"
+features = ["extra-traits"]
+
+[dependencies.synstructure]
+version = "0.12"
+optional = true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 *WARNING* this crate is very experimental
 
+*NOTE* this crate targets ocaml-rs 0.5.1
+
 derive-ocaml is based on top of [ocaml-rs](https://github.com/zshipko/ocaml-rs) and adds a custom derive macro for `FromValue` and `ToValue`.
 The macro supports structs, enums, and unboxed float records.
 
@@ -23,4 +25,4 @@ pub fn rust_add_vecs(l: Vec3, r: Vec3) -> Vec3 {
 }
 ```
 
-see `src/example/src/lib.rs` and `src/example/src/stubs.ml` for example
+see `example/src/lib.rs` and `example/src/stubs.ml` for example

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -4,8 +4,11 @@ version = "0.1.0"
 authors = ["joris giovannangeli <joris.giovannangeli@ahrefs.com>"]
 
 [dependencies]
-derive-ocaml = { version = "0.1.1", features= ["stubs", "derive"] }
-ocaml = "*"
+ocaml = "0.5.1"
+
+[dependencies.derive-ocaml]
+path = ".."
+features = ["stubs", "derive"]
 
 [lib]
 crate-type = ["staticlib"]

--- a/example/dune
+++ b/example/dune
@@ -4,13 +4,14 @@
  (deps (source_tree .))
  (targets libexample_stubs.a)
  (action (progn
-          (run cargo build -Z unstable-options --out-dir . --target-dir ../rust --release)
+          (system "cd .. && cargo build --release")
+          (system "cp ../../target/release/libexample_stubs.a .")
           )))
 
 (library
    (name stubs)
    (modules stubs)
-   (self_build_stubs_archive (example))
+   (foreign_archives example_stubs)
    (c_library_flags         (-lpthread -lc -lm))
    )
 

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro)]
-
 #[macro_use]
 extern crate derive_ocaml;
 #[macro_use]
@@ -49,4 +47,9 @@ pub fn rust_sum_vecs(vectors: Unrolled<Vec3>, max_items: Bound) -> Vec3 {
         One(vec) => vec,
         Many(vectors) => vectors.into_iter().take(max_items.0).fold(Default::default(), Vec3::add),
     }
+}
+
+#[ocaml_ffi(ffi_exn="rust-ffi")]
+pub fn test_panic() {
+    panic!("Oh No!")
 }

--- a/example/src/main.ml
+++ b/example/src/main.ml
@@ -1,3 +1,5 @@
+exception TestFail
+
 let _ =
   let open Stubs in
   let v1 = { x = 1.; y= 2.; z = 3. } in
@@ -6,4 +8,11 @@ let _ =
   let v4 = add_vecs v1 v3 in
   let v5 = add_vecs v4 v2 in
   let sum = sum_vecs (Many [| v1; v2; v3; v4; v5 |]) { bound = 3 } in
-  Printf.printf "[ %.2f; %.2f; %.2f ]\n" sum.x sum.y sum.z
+  Printf.printf "[ %.2f; %.2f; %.2f ]\n" sum.x sum.y sum.z;
+
+  let open Stubs in
+  try
+    test_panic ();
+    raise TestFail
+  with
+  | RustFFI err -> Printf.printf "got rust ffi panic message: %s\n" err

--- a/example/src/stubs.ml
+++ b/example/src/stubs.ml
@@ -13,5 +13,13 @@ type 'item unrolled =
   | One of 'item
   | Many of 'item array
 
+(* if you want to intercept ffi with custom ocaml exception,
+   make sure the custom exception is registered like the following,
+   and annotate the ffi function with `ffi_exn = "<exception name>"`
+*)
+exception RustFFI of string
+let _ = Callback.register_exception "rust-ffi" (RustFFI "ffi panic")
+
 external add_vecs : vec3 -> vec3 -> vec3 = "rust_add_vecs"
 external sum_vecs : vec3 unrolled -> bound -> vec3 = "rust_sum_vecs"
+external test_panic : unit -> unit = "test_panic"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
-extern crate quote;
 #[cfg(feature = "stubs")]
 extern crate proc_macro;
 extern crate proc_macro2;
+extern crate quote;
 extern crate syn;
 
 #[cfg(feature = "stubs")]

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -8,46 +8,65 @@ struct OcamlParam {
     typ: Type,
 }
 
-fn args_to_rust_vars<'a>(args: &'a [OcamlParam]) -> impl 'a + Iterator<Item = proc_macro2::TokenStream> {
-    args.iter().filter_map(|arg| {
-        match arg.ident {
-            None => None,
-            Some(ref ident) => {
-                let typ = &arg.typ;
-                Some(quote!( <#typ as ::ocaml::FromValue>::from_value(#ident)))
-            },
+struct OcamlFFIAttrs {
+    ffi_exn: Option<String>,
+}
+
+fn args_to_rust_vars<'a>(
+    args: &'a [OcamlParam],
+) -> impl 'a + Iterator<Item = proc_macro2::TokenStream> {
+    args.iter().filter_map(|arg| match arg.ident {
+        None => None,
+        Some(ref ident) => {
+            let typ = &arg.typ;
+            Some(quote!( <#typ as ::ocaml::FromValue>::from_value(#ident)))
         }
     })
 }
 
 fn args_names<'a>(args: &'a [OcamlParam]) -> impl 'a + Iterator<Item = proc_macro2::TokenStream> {
-    args.iter().filter_map(|arg| arg.ident.as_ref().map(|ident| quote!(#ident)))
+    args.iter()
+        .filter_map(|arg| arg.ident.as_ref().map(|ident| quote!(#ident)))
 }
 
-pub fn ocaml(_attribute: TokenStream, function: TokenStream) -> TokenStream {
+fn parse_attr_args(args: &[NestedMeta]) -> OcamlFFIAttrs {
+    let mut ffi_exn = None;
+    for arg in args {
+        match arg {
+            NestedMeta::Meta(Meta::NameValue(MetaNameValue {
+                path,
+                lit: Lit::Str(value),
+                ..
+            })) if path.is_ident("ffi_exn") => ffi_exn = Some(value.value()),
+            _ => panic!("unrecognized argument {:?}", arg),
+        }
+    }
+    OcamlFFIAttrs { ffi_exn }
+}
+
+pub fn ocaml(attribute: TokenStream, function: TokenStream) -> TokenStream {
     let ItemFn {
-        ident,
-        block,
-        decl,
         attrs,
+        block,
+        sig,
         vis,
         ..
-    } = match syn::parse(function).expect("failed to parse tokens as a function") {
-        Item::Fn(item) => item,
-        _ => panic!("#[ocaml] can only be applied to functions"),
-    };
+    } = parse_macro_input!(function as ItemFn);
+    let attr_args = parse_macro_input!(attribute as AttributeArgs);
+    let ffi_attrs = parse_attr_args(&attr_args);
     match vis {
         syn::Visibility::Public(_) => (),
         _ => panic!("#[ocaml] functions must be public"),
     };
-    let FnDecl {
+    let Signature {
+        ident,
         inputs,
         output,
         variadic,
         generics,
         fn_token,
         ..
-    } = { *decl };
+    } = sig;
 
     if !generics.params.is_empty() {
         panic!("#[ocaml] functions must not have generics")
@@ -61,75 +80,94 @@ pub fn ocaml(_attribute: TokenStream, function: TokenStream) -> TokenStream {
         .enumerate()
         .map(|(i, input)| {
             match *input {
-                FnArg::SelfRef(_) | FnArg::SelfValue(_) => panic!("#[ocaml] can only be applied to plain functions, methods are not supported at argument {}", i),
-                FnArg::Inferred(_) => panic!("#[ocaml] does not support inferred types at argument {}"),
-                FnArg::Ignored(_) => panic!("#[ocaml] ignored type unsupported"),
-                FnArg::Captured(ArgCaptured {
-                    pat: syn::Pat::Ident(syn::PatIdent {
-                        ref ident,
-                        by_ref: None,
-                        subpat: None,
-                        ..
-                    }),
-                    ref ty,
-                    ..
-                }) => {
-                    let typ = ty.clone();
-                    OcamlParam { ident: Some(ident.clone()), typ }
-                },
-                FnArg::Captured(ArgCaptured {
-                    pat: syn::Pat::Wild(_),
-                    ref ty,
-                    ..
-                }) =>
-                { let typ = ty.clone(); OcamlParam { ident: None, typ }},
-                FnArg::Captured(_) => panic!("#[ocaml] only supports simple argument patterns at argument {}", i),
+                FnArg::Receiver(_) => panic!("#[ocaml] can only be applied to plain functions, methods are not supported at argument {}", i),
+                FnArg::Typed(ref arg) => {
+                    if let Type::Infer(_) = *arg.ty {
+                        panic!("#[ocaml] does not support inferred types at argument {}")
+                    }
+                    match *arg.pat {
+                        Pat::Wild(_) => OcamlParam { ident: None, typ: Type::clone(&*arg.ty) },
+                        Pat::Ident(PatIdent { ref ident, by_ref: None, subpat: None, .. }) => OcamlParam { ident: Some(ident.clone()), typ: Type::clone(&*arg.ty) },
+                        _ => panic!("#[ocaml] only supports simple argument patterns at argument {:?}", arg),
+                    }
+                }
             }
         })
         .collect::<Vec<OcamlParam>>();
 
     let where_clause = &generics.where_clause;
     let (returns, return_ty, rust_ty) = match output {
-        rust_ty @ ReturnType::Type(_, _) => (true, quote!( -> ::ocaml::core::mlvalues::Value), quote!(#rust_ty)),
+        rust_ty @ ReturnType::Type(_, _) => (
+            true,
+            quote!( -> ::ocaml::core::mlvalues::Value),
+            quote!(#rust_ty),
+        ),
         ReturnType::Default => (false, quote!(), quote!()),
     };
     let params = args_names(&args).collect::<Vec<_>>();
     let rust_code = {
-        let inputs = inputs.clone();
+        let inputs = inputs.iter();
         // Generate an internal function so that ? and return properly works
         quote!(
             #[inline(always)]
-            fn internal( #(#inputs), * ) #rust_ty {
+            fn internal( #(#inputs),* ) #rust_ty {
                 #block
             }
-         )};
+        )
+    };
     let arguments = args_to_rust_vars(&args);
+    let ffi_exn_id = if let Some(ffi_exn) = &ffi_attrs.ffi_exn {
+        let ffi_exn = syn::LitStr::new(ffi_exn, proc_macro2::Span::call_site());
+        quote!(
+            ::std::option::Option::Some(#ffi_exn.to_string())
+        )
+    } else {
+        quote!(::std::option::Option::None)
+    };
     let body = if returns {
         quote!(
             #rust_code
             ::ocaml::caml_body!{ | #(#params), * |, <return_value>, {
-                let rust_val = internal(#(#arguments),*);
-                return_value = ::ocaml::ToValue::to_value(&rust_val);
-            }
-            };
-            return ::ocaml::core::mlvalues::Value::from(return_value);
+                let rust_val = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(move || { internal(#(#arguments),*) }));
+                match rust_val {
+                    Ok(rust_val) =>
+                        return_value = ::ocaml::ToValue::to_value(&rust_val),
+                    Err(_) => {
+                        if let Some(exn_tag) = #ffi_exn_id.and_then(|id: ::std::string::String| ::ocaml::named_value(id)) {
+                            ::ocaml::runtime::raise_with_string(&exn_tag, "rust ffi panic")
+                        } else {
+                            let exn_val =
+                                ::ocaml::Value::from(::ocaml::Str::from("no rust ffi exception is registered"));
+                            ::ocaml::runtime::invalid_argument_value(
+                                &exn_val)
+                        }
+                    }
+                }
+            }};
+            ::ocaml::core::mlvalues::Value::from(return_value)
         )
     } else {
         quote!(
             #rust_code
             ::ocaml::caml_body!{ | #(#params), * |, @code {
-                internal(#(#arguments),*);
+                let rust_val = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(move || { internal(#(#arguments),*) }));
+                if let Err(_) = rust_val {
+                    if let Some(exn_tag) = #ffi_exn_id.and_then(|id: ::std::string::String| ::ocaml::named_value(id)) {
+                        ::ocaml::runtime::raise_with_string(&exn_tag, "rust ffi panic")
+                    } else {
+                        let exn_val =
+                            ::ocaml::Value::from(::ocaml::Str::from("no rust ffi exception is registered"));
+                        ::ocaml::runtime::invalid_argument_value(
+                            &exn_val)
+                    }
+                }
             }};
-            return
         )
     };
-    let inputs = args.iter()
-        .map(|arg| {
-             match arg.ident {
-                 Some(ref ident) => quote!{ mut #ident: ::ocaml::core::mlvalues::Value },
-                 None => quote!{ _: ::ocaml::core::mlvalues::Value },
-             }
-        });
+    let inputs = args.iter().map(|arg| match arg.ident {
+        Some(ref ident) => quote! { mut #ident: ::ocaml::core::mlvalues::Value },
+        None => quote! { _: ::ocaml::core::mlvalues::Value },
+    });
 
     let output = quote! {
         #[no_mangle]


### PR DESCRIPTION
At the moment Rust does not prevent unwinding the stack into OCaml and further undefined behavior due to this. This PR will prevent stack unwinding at the FFI boundary and raise an OCaml exception instead, either through a custom and registered exception or just the stock invalid argument exception.

This can be further extended to allow registration of a panic handler in the future, if there is a need for such.